### PR TITLE
add required status check to repository ruleset

### DIFF
--- a/repository/main.tf
+++ b/repository/main.tf
@@ -70,5 +70,16 @@ resource "github_repository_ruleset" "main" {
       dismiss_stale_reviews_on_push     = true
       require_last_push_approval        = true
     }
+
+    dynamic "required_status_checks" {
+      for_each = var.required_status_check != null ? [1] : []
+      content {
+        strict_required_status_checks_policy = true
+
+        required_check {
+          context = var.required_status_check
+        }
+      }
+    }
   }
 }

--- a/repository/variables.tf
+++ b/repository/variables.tf
@@ -72,3 +72,9 @@ variable "branch_protection" {
   type        = bool
   default     = true
 }
+
+variable "required_status_check" {
+  description = "The name of the status check context that must pass before merging. Set to `null` to disable status check requirement."
+  type        = string
+  default     = "build_branch"
+}


### PR DESCRIPTION
## Summary
- Adds `required_status_checks` block to the repository ruleset to block merges when CI fails
- Introduces configurable `required_status_check` variable (defaults to `build_branch`)
- Uses `strict_required_status_checks_policy = true` to require branches to be up-to-date

## Test plan
- [ ] Run `tofu plan` to verify no syntax errors
- [ ] Apply to a test repository and verify status checks are enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)