### PR TITLE
add optional dev team repository association

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ module "my_repo" {
 }
 ```
 
+## Development Guidelines
+
+Before making any changes to this module, consult the official GitHub Terraform provider documentation at https://registry.terraform.io/providers/integrations/github/latest/docs to ensure compatibility with the latest provider version and best practices.
+
 ## Key Configuration Notes
 
 - `branch_protection` defaults to `true` but must be `false` for private repos on free GitHub plans (rulesets have the same plan restrictions as the legacy branch protection)

--- a/repository/main.tf
+++ b/repository/main.tf
@@ -45,6 +45,13 @@ resource "github_repository" "this" {
   }
 }
 
+resource "github_team_repository" "developers" {
+  count      = var.dev_team_id != null ? 1 : 0
+  team_id    = var.dev_team_id
+  repository = github_repository.this.name
+  permission = "push"
+}
+
 resource "github_repository_ruleset" "main" {
   count       = var.branch_protection ? 1 : 0
   name        = "main-branch-protection"

--- a/repository/variables.tf
+++ b/repository/variables.tf
@@ -78,3 +78,9 @@ variable "required_status_check" {
   type        = string
   default     = "build_branch"
 }
+
+variable "dev_team_id" {
+  description = "The ID of the developers team to grant push access. Set to `null` to skip team association."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary
- Add `dev_team_id` variable to automatically create `github_team_repository` resource with push permission
- Reduces boilerplate when using the module by eliminating separate `github_team_repository` resource declarations
- Add development guidelines to CLAUDE.md requiring consultation of official GitHub provider docs

## Test plan
- [ ] Run `terraform validate` on a project using this module with `dev_team_id` set
- [ ] Run `terraform plan` to verify the team repository resource is created correctly
- [ ] Test without `dev_team_id` to ensure backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)