### PR TITLE
add allowed_merge_methods to ruleset

### DIFF
--- a/repository/main.tf
+++ b/repository/main.tf
@@ -69,6 +69,7 @@ resource "github_repository_ruleset" "main" {
       required_review_thread_resolution = true
       dismiss_stale_reviews_on_push     = true
       require_last_push_approval        = true
+      allowed_merge_methods             = ["squash"]
     }
 
     dynamic "required_status_checks" {


### PR DESCRIPTION
## Summary
- Add `allowed_merge_methods = ["squash"]` to the repository ruleset's `pull_request` block
- Enforces squash-only merges at the ruleset level, matching the repository settings (`allow_squash_merge = true`, others disabled)

## Test plan
- [ ] Run `terraform validate` on a project using this module with `branch_protection = true`
- [ ] Run `terraform plan` to verify the ruleset includes the new allowed_merge_methods setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)