### PR TITLE
Fix private repo forking and remove deprecated has_downloads

### DIFF
--- a/repository/main.tf
+++ b/repository/main.tf
@@ -22,7 +22,6 @@ resource "github_repository" "this" {
   has_discussions        = var.has_discussions
   has_projects           = var.has_projects
   has_wiki               = var.has_wiki
-  has_downloads          = false
   allow_merge_commit     = false
   allow_squash_merge     = true
   allow_rebase_merge     = false
@@ -31,6 +30,7 @@ resource "github_repository" "this" {
   auto_init              = true
   license_template       = var.license_template
   allow_update_branch    = true
+  allow_forking          = var.private ? false : true
   topics                 = var.topics
   dynamic "pages" {
     for_each = var.pages_url != null ? [1] : []


### PR DESCRIPTION
## Summary
- Add `allow_forking = var.private ? false : true` to disable forking for private repos, preventing "organization does not allow private repository forking" errors
- Remove deprecated `has_downloads` attribute

## Test plan
- [ ] Apply to an existing private repository to verify no forking error occurs
- [ ] Verify public repositories still allow forking by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)