### PR TITLE
enable has_issues by default

### DIFF
--- a/repository/variables.tf
+++ b/repository/variables.tf
@@ -34,7 +34,7 @@ variable "pages_url" {
 variable "has_issues" {
   description = "Set to `true` to enable the GitHub Issues features on the repository"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "has_discussions" {


### PR DESCRIPTION
## Summary
- Changes the default value of `has_issues` from `false` to `true`
- Issues are commonly used for most repositories, making `true` a more sensible default

## Test plan
- [ ] Verify terraform plan shows no changes for repos that already have issues enabled
- [ ] Verify new repos created with the module have issues enabled by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)