### PR TITLE
add is_template variable to repository module

### DIFF
--- a/repository/main.tf
+++ b/repository/main.tf
@@ -32,6 +32,7 @@ resource "github_repository" "this" {
   allow_update_branch    = true
   allow_forking          = var.private ? false : true
   topics                 = var.topics
+  is_template            = var.is_template
   dynamic "pages" {
     for_each = var.pages_url != null ? [1] : []
     content {

--- a/repository/variables.tf
+++ b/repository/variables.tf
@@ -84,3 +84,9 @@ variable "dev_team_id" {
   type        = string
   default     = null
 }
+
+variable "is_template" {
+  description = "Set to `true` to make this repository available as a template repository"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Add `is_template` variable to enable GitHub template repository functionality
- Defaults to `false` to maintain backward compatibility

## Test plan
- [ ] Run `terraform validate` to verify configuration is valid
- [ ] Apply to a test repository with `is_template = true` to verify template creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)