### PR TITLE
target main branch explicitly in ruleset

### DIFF
--- a/repository/main.tf
+++ b/repository/main.tf
@@ -62,7 +62,7 @@ resource "github_repository_ruleset" "main" {
 
   conditions {
     ref_name {
-      include = ["~DEFAULT_BRANCH"]
+      include = ["refs/heads/main"]
       exclude = []
     }
   }


### PR DESCRIPTION
## Summary
- Change ruleset `ref_name` from `~DEFAULT_BRANCH` to `refs/heads/main`
- Ensures branch protection applies specifically to the `main` branch rather than whatever the default branch is set to

## Test plan
- [ ] Run `terraform plan` to verify no unexpected changes
- [ ] Verify ruleset targets `main` branch after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)